### PR TITLE
Prevent stackoverflow errors to kill UdpMessageChannel thread

### DIFF
--- a/src/examples/nistgoodies/pluggablelogger/StackLoggerImpl.java
+++ b/src/examples/nistgoodies/pluggablelogger/StackLoggerImpl.java
@@ -80,7 +80,7 @@ public class StackLoggerImpl implements StackLogger {
         logger.error(string);
     }
 
-    public void logError(String string, Exception exception) {
+    public void logError(String string, Throwable exception) {
       logger.error(string,exception);
 
     }

--- a/src/gov/nist/core/CommonLogger.java
+++ b/src/gov/nist/core/CommonLogger.java
@@ -86,9 +86,9 @@ public class CommonLogger implements StackLogger{
 		logger().logError(message);
 	}
 	
-	public void logError(String message, Exception ex) {
+	public void logError(String message, Throwable throwable) {
 		
-		logger().logError(message, ex);
+		logger().logError(message, throwable);
 	}
 	
 	public void logException(Throwable ex) {

--- a/src/gov/nist/core/CommonLoggerLog4j.java
+++ b/src/gov/nist/core/CommonLoggerLog4j.java
@@ -209,11 +209,11 @@ public class CommonLoggerLog4j implements StackLogger {
      * Log an error message.
      *
      * @param message
-     * @param ex
+     * @param throwable
      */
-    public void logError(String message, Exception ex) {
+    public void logError(String message, Throwable throwable) {
         Logger logger = this.getLogger();
-        logger.error(message, ex);
+        logger.error(message, throwable);
 
     }
 

--- a/src/gov/nist/core/LogWriter.java
+++ b/src/gov/nist/core/LogWriter.java
@@ -418,11 +418,11 @@ public class LogWriter implements StackLogger {
      * Log an error message.
      *
      * @param message
-     * @param ex
+     * @param throwable
      */
-    public void logError(String message, Exception ex) {
+    public void logError(String message, Throwable throwable) {
         Logger logger = this.getLogger();
-        logger.error(message, ex);
+        logger.error(message, throwable);
 
     }
 

--- a/src/gov/nist/core/StackLogger.java
+++ b/src/gov/nist/core/StackLogger.java
@@ -79,9 +79,9 @@ public interface StackLogger extends LogLevels {
      * Log an error message.
      *
      * @param message
-     * @param ex
+     * @param throwable
      */
-    public void logError(String message, Exception ex);
+    public void logError(String message, Throwable throwable);
     /**
      * Log a warning mesasge.
      *

--- a/src/gov/nist/javax/sip/stack/UDPMessageChannel.java
+++ b/src/gov/nist/javax/sip/stack/UDPMessageChannel.java
@@ -318,6 +318,9 @@ public class UDPMessageChannel extends MessageChannel implements
 
                 logger.logError(
                         "Error while processing incoming UDP packet" + Arrays.toString(packet.getData()), e);
+            } catch (StackOverflowError e) {
+                logger.logError("StackOverflowError while processing incoming UDP packet" + Arrays.toString(packet.getData()));
+                logger.logException(e);
             }
             this.incomingPacket = null;
             if (sipStack.threadPoolSize == -1) {

--- a/src/gov/nist/javax/sip/stack/UDPMessageChannel.java
+++ b/src/gov/nist/javax/sip/stack/UDPMessageChannel.java
@@ -314,13 +314,10 @@ public class UDPMessageChannel extends MessageChannel implements
             // Process the packet. Catch and log any exception we may throw.
             try {
                 processIncomingDataPacket(packet);
-            } catch (Exception e) {
+            } catch (Throwable t) {
 
                 logger.logError(
-                        "Error while processing incoming UDP packet" + Arrays.toString(packet.getData()), e);
-            } catch (StackOverflowError e) {
-                logger.logError("StackOverflowError while processing incoming UDP packet" + Arrays.toString(packet.getData()));
-                logger.logException(e);
+                        "Error while processing incoming UDP packet" + Arrays.toString(packet.getData()), t);
             }
             this.incomingPacket = null;
             if (sipStack.threadPoolSize == -1) {


### PR DESCRIPTION
We have enconter a stackoverflow error originating from UdpMessageChannel killing the thread in the process making our application no longuer able to process packet. We want to make sure that this error does not kill the thread in the future to avoid down time. 